### PR TITLE
Fix bump versions and publish packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Bump versions and publish packages
         run: |
-          npx lerna version --yes --conventional-commits --create-release github --message 'chore(release): publish'
+          npx lerna version --yes --conventional-commits --message 'chore(release): publish'
           npx lerna publish from-package --yes
 
       - name: Get Current Version


### PR DESCRIPTION
This pull request fixes an issue with the `Bump versions and publish packages` step in the release workflow. Previously, the command used to bump versions and publish packages included the `--create-release github` flag, which was causing an error. This PR removes that flag from the command, resolving the issue.