### PR TITLE
Set public access for npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
+      - name: Set public access
+        shell: bash
+        run: npm config set access public
+
       - name: Get npm cache directory
         id: npm-cache-dir
         shell: bash


### PR DESCRIPTION
This pull request sets the public access for npm by adding a step to the CI workflow that runs the command `npm config set access public`.